### PR TITLE
adding with =/total/sum keywords

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -516,7 +516,7 @@ export async function copyLastValue(values) {
   }
 }
 
-export function onEditorKeydown(e) {
+function onEditorKeydown(e) {
   let key = e.key;
   // Order of below conditions matter since there is subset condition
   if (key === "Enter" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
@@ -539,33 +539,37 @@ function insertNode(...nodes) {
   }
 }
 
-function is_total_keywords(word) {
+function isTotalKeyword(word) {
   return ["total", "sum", "="].includes(word.toLowerCase().trim());
 }
 
 export function postProcess(inputs, outputs) {
-  if (inputs.length === 0) {
-    return outputs;
-  }
-  // confirm if input length and output length
-  if (inputs.length !== outputs.length) {
-    console.error(
-      "Post Processing failed. Input and Output lengths must be same."
-    );
-    return outputs;
-  }
-  // processing for total keyword
-  let total = 0;
-  for (let index = 0; index < outputs.length; index++) {
-    if (typeof outputs[index] === "number") {
-      total += outputs[index];
+  try {
+    if (inputs.length === 0) {
+      return outputs;
     }
+    // confirm if input length and output length
+    if (inputs.length !== outputs.length) {
+      console.error(
+        "Post Processing failed. Input and Output lengths must be same."
+      );
+      return outputs;
+    }
+    // processing for total keyword
+    let total = 0;
+    for (let index = 0; index < outputs.length; index++) {
+      if (typeof outputs[index] === "number") {
+        total += outputs[index];
+      }
 
-    if (is_total_keywords(inputs[index])) {
-      outputs[index] = total;
+      if (isTotalKeyword(inputs[index])) {
+        outputs[index] = total;
+      }
     }
+    return outputs;
+  } catch {
+    return outputs;
   }
-  return outputs;
 }
 
 export function evaluate(value) {

--- a/js/editor.js
+++ b/js/editor.js
@@ -505,24 +505,25 @@ function findLastValue(values) {
   return lastValue ? lastValue.result : null;
 }
 
-export async function copyLastValue(values, paste = false) {
+export async function copyLastValue(values) {
   // copy the last result to clipboard
   const lastValue = findLastValue(values);
   if (_.isNumber(lastValue)) {
     copyValueToClipboard(lastValue);
-    if (paste) {
-      insertNode(lastValue);
-    }
+    return lastValue;
   } else {
     showToastMessage(`No result to copy`);
   }
 }
 
-function onEditorKeydown(e) {
+export function onEditorKeydown(e) {
   let key = e.key;
   // Order of below conditions matter since there is subset condition
   if (key === "Enter" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
-    copyLastValue(evaluatedValues, true);
+    let lastValue = copyLastValue(evaluatedValues);
+    if (lastValue) {
+      insertNode(lastValue);
+    }
   } else if (key === "Enter" && (e.metaKey || e.ctrlKey)) {
     copyLastValue(evaluatedValues);
   } else if (key === "/" && (e.metaKey || e.ctrlKey)) {
@@ -542,7 +543,7 @@ function is_total_keywords(word) {
   return ["total", "sum", "="].includes(word.toLowerCase().trim());
 }
 
-function post_process(inputs, outputs) {
+export function postProcess(inputs, outputs) {
   if (inputs.length === 0) {
     return outputs;
   }
@@ -571,7 +572,7 @@ export function evaluate(value) {
   let lines = value.split("\n");
   evaluatedValues = [];
   let results = useMathJs(lines);
-  results = post_process(lines, results);
+  results = postProcess(lines, results);
   for (let index = 0; index < results.length; index++) {
     const result_expression = {
       type: "expression",

--- a/js/editor.test.js
+++ b/js/editor.test.js
@@ -282,7 +282,7 @@ describe("testing parse", () => {
 
 describe("testing postProcess", () => {
   it("should return outputs when inputs and outputs lengths are equal", () => {
-    const inputs = ["2", "total", "3"];
+    const inputs = ["2", "=", "3"];
     const outputs = [2, "", 3];
     const result = postProcess(inputs, outputs);
     expect(result).toEqual([2, 2, 3]);
@@ -296,7 +296,7 @@ describe("testing postProcess", () => {
   });
 
   it("should handle different lengths of inputs and outputs", () => {
-    const inputs = ["2", "total", "3"];
+    const inputs = ["2", "sum", "3"];
     const outputs = [2, 5];
     const result = postProcess(inputs, outputs);
     expect(result).toEqual([2, 5]);

--- a/js/editor.test.js
+++ b/js/editor.test.js
@@ -6,6 +6,7 @@ import {
   copyLastValue,
   getTitle,
   initSentry,
+  postProcess,
   parse,
 } from "./editor";
 import { describe, it, expect, vi, test, beforeEach } from "vitest";
@@ -137,6 +138,21 @@ describe("testing evaluate", () => {
     const evalValues = await evaluate("data=10+10-1\ndata +2.5-0.50001x1.1");
     expect(evalValues[1].result).toBeCloseTo(20.949);
   });
+
+  test("Evaluate multi-line with total keyword 1: = ", async () => {
+    const evalValues = await evaluate("data=10\n+10-1\ndata +2.5-0.50\n=");
+    expect(evalValues[3].result).toBeCloseTo(31);
+  });
+
+  test("Evaluate multi-line with total keyword 2: total ", async () => {
+    const evalValues = await evaluate("10\n+10-1\n10x3\ntotal");
+    expect(evalValues[3].result).toBeCloseTo(49);
+  });
+
+  test("Evaluate multi-line with total keyword 3: sum ", async () => {
+    const evalValues = await evaluate("data=10\n+10-1\ndata +2.5\nsum");
+    expect(evalValues[3].result).toBeCloseTo(31.5);
+  });
 });
 
 // Mocking necessary parts of the global scope and DOM
@@ -228,8 +244,8 @@ vi.mock("@sentry/browser", () => ({
 }));
 
 describe("Testing initSentry", () => {
-  it("should initialize Sentry with the correct configuration", () => {
-    initSentry();
+  it("should initialize Sentry with the correct configuration", async () => {
+    await initSentry();
 
     expect(Sentry.init).toHaveBeenCalledWith({
       dsn: "https://f6181e1f6794abaf08674441d2c08403@o4507406315159552.ingest.de.sentry.io/4507406320992336",
@@ -261,5 +277,35 @@ describe("testing parse", () => {
     parse(editor.innerText, output);
     await new Promise(setImmediate); // Wait for async operations
     expect(output.querySelectorAll("button")[0].innerText).toBe("4");
+  });
+});
+
+describe("testing postProcess", () => {
+  it("should return outputs when inputs and outputs lengths are equal", () => {
+    const inputs = ["2", "total", "3"];
+    const outputs = [2, "", 3];
+    const result = postProcess(inputs, outputs);
+    expect(result).toEqual([2, 2, 3]);
+  });
+
+  it("should return outputs adding previous inputs when inputs and outputs lengths are equal", () => {
+    const inputs = ["2", "5", "total", "3"];
+    const outputs = [2, 5, "", 3];
+    const result = postProcess(inputs, outputs);
+    expect(result).toEqual([2, 5, 7, 3]);
+  });
+
+  it("should handle different lengths of inputs and outputs", () => {
+    const inputs = ["2", "total", "3"];
+    const outputs = [2, 5];
+    const result = postProcess(inputs, outputs);
+    expect(result).toEqual([2, 5]);
+  });
+
+  it("should handle empty inputs", () => {
+    const inputs = [];
+    const outputs = [2, 5];
+    const result = postProcess(inputs, outputs);
+    expect(result).toEqual([2, 5]);
   });
 });

--- a/js/help_operators.json
+++ b/js/help_operators.json
@@ -11,6 +11,11 @@
       "Example": "5 - 2 = 3"
     },
     {
+      "Name": "Total",
+      "Operator": ["=", "sum", "total"],
+      "Example": ["2+1", "3+4", "= 10 (Adds up all the above values"]
+    },
+    {
       "Name": "Multiplication",
       "Operator": ["*", "x"],
       "Example": ["2 * 3 = 6", "2 x 3 = 6"]

--- a/js/help_page.test.js
+++ b/js/help_page.test.js
@@ -13,7 +13,7 @@ describe("createHelpTables tests", () => {
   it("should create shortcut tables contents", () => {
     const shortcutTables = document.getElementById("shortcut-table-container");
     expect(shortcutTables.querySelectorAll("td")[4].outerHTML).toEqual(
-      "<td>Open/Close calculator History</td>"
+      "<td>Open/Close help</td>"
     );
   });
 

--- a/js/help_shortcuts.json
+++ b/js/help_shortcuts.json
@@ -1,8 +1,12 @@
 {
   "shortcuts": [
     {
-      "Action": "Copy last result",
-      "Shortcut": "Ctrl + Enter"
+      "Action": "Paste the last result",
+      "Shortcut": "Ctrl + Shift + Enter / Command + Shift + Enter"
+    },
+    {
+      "Action": "Copy the last result",
+      "Shortcut": "Ctrl + Enter / Command + Enter"
     },
     {
       "Action": "Open/Close help",


### PR DESCRIPTION
Changes:
- Adding keywords to support total of all values by `=`/`sum`/`total`
- Adding Sentry activities async so initial time to load is not affected
- Adding a keyboard shortcut to copy & paste the last result