### PR TITLE
fix: copy paste last value pasting a promise

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -517,8 +517,9 @@ function findLastValue(values) {
 
 export async function copyLastValue(values) {
   // copy the last result to clipboard
-  const lastValue = findLastValue(values);
+  let lastValue = findLastValue(values);
   if (_.isNumber(lastValue)) {
+    lastValue = parseFloat(lastValue.toFixed(5));
     copyValueToClipboard(lastValue);
     return lastValue;
   } else {

--- a/js/editor.js
+++ b/js/editor.js
@@ -505,13 +505,13 @@ function debounce(callback, wait) {
   };
 }
 
-function isNotEmptyResult(item) {
+function isNumberResult(item) {
   return !_.isEmpty(item) && _.isNumber(item.result);
 }
 
 // find the last not empty value from evaluatedValues
 function findLastValue(values) {
-  let lastValue = values.findLast(isNotEmptyResult);
+  let lastValue = values.findLast(isNumberResult);
   return lastValue ? lastValue.result : null;
 }
 
@@ -526,24 +526,32 @@ export async function copyLastValue(values) {
   }
 }
 
-function onEditorKeydown(e) {
+export async function copyPasteLastValue(values) {
+  let lastValue = await copyLastValue(values);
+  if (lastValue) {
+    insertNode(lastValue);
+  }
+}
+
+async function onEditorKeydown(e) {
   let key = e.key;
   // Order of below conditions matter since there is subset condition
   if (key === "Enter" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
-    let lastValue = copyLastValue(evaluatedValues);
-    if (lastValue) {
-      insertNode(lastValue);
-    }
+    // copy & paste last value
+    copyPasteLastValue(evaluatedValues);
   } else if (key === "Enter" && (e.metaKey || e.ctrlKey)) {
+    // copy last value
     copyLastValue(evaluatedValues);
   } else if (key === "/" && (e.metaKey || e.ctrlKey)) {
+    // open/close help
     toggleHelpOverlay();
   } else if (key === "h" && (e.metaKey || e.ctrlKey)) {
+    // open/close history
     toggleHistory();
   }
 }
 
-function insertNode(...nodes) {
+export function insertNode(...nodes) {
   for (let node of nodes) {
     document.execCommand("insertText", false, node);
   }

--- a/js/help_page.test.js
+++ b/js/help_page.test.js
@@ -1,5 +1,5 @@
 import { createHelpTables } from "./help_page";
-import { describe, it, expect } from "vitest";
+import { describe, test, expect } from "vitest";
 import path from "path";
 import fs from "fs";
 
@@ -10,21 +10,21 @@ describe("createHelpTables tests", () => {
 
   createHelpTables();
 
-  it("should create shortcut tables contents", () => {
+  test("should create shortcut tables contents", () => {
     const shortcutTables = document.getElementById("shortcut-table-container");
     expect(shortcutTables.querySelectorAll("td")[4].outerHTML).toEqual(
       "<td>Open/Close help</td>"
     );
   });
 
-  it("should create operator tables contents", () => {
+  test("should create operator tables contents", () => {
     const operatorTables = document.getElementById("operator-table-container");
     expect(operatorTables.querySelectorAll("td")[2].outerHTML).toEqual(
       "<td>2 + 3 = 5</td>"
     );
   });
 
-  it("should create unit tables contents", () => {
+  test("should create unit tables contents", () => {
     const unitTables = document.getElementById("unit-table-container");
     expect(unitTables.querySelectorAll("td")[5].outerHTML).toEqual(
       "<td>m2, sqin, sqft, sqyd, sqmi, sqrd, sqch, sqmil, acre, hectare</td>"

--- a/js/utils/convert_x_to_multiply.test.js
+++ b/js/utils/convert_x_to_multiply.test.js
@@ -1,8 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, test, expect } from "vitest";
 import { convertXToMultiplication } from "./convert_x_to_multiply";
 
 describe("testing convertXToMultiplication", () => {
-  it("Convert all 'x' to multiplication operator", () => {
+  test("Convert all 'x' to multiplication operator", () => {
     const lines = [
       "2x3",
       "2 x 3",
@@ -25,7 +25,7 @@ describe("testing convertXToMultiplication", () => {
     ]);
   });
 
-  it("Dont convert some 'x' to multiplication operator in expressions", () => {
+  test("Dont convert some 'x' to multiplication operator in expressions", () => {
     const lines = ["2xdata", "0x90 x 2", "0x90x 2", "x22e x2x4x1.7x0.41"];
     const convertedLines = convertXToMultiplication(lines);
 


### PR DESCRIPTION
Changes:
- Removing the `it` and using `test` to be consistent in the unit tests
- Fix for the bug where the Promise object is printed instead of pasting the last numeric value
- Added unit tests for the above fix and its relevant methods
- round of copied values using keyboard shortcuts