### PR TITLE
chore: upgrading mathjs to 14.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 **/.DS_Store
 # Sentry Config File
 .env.sentry-build-plugin
+assets/.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "braces": "3.0.3",
         "country-to-currency": "^1.1.5",
         "lodash": "^4.17.21",
-        "mathjs": "^12.4.3",
+        "mathjs": "^14.4.0",
         "show-toast": "^1.1.4",
         "web-browser-storage": "^0.1.14"
       },
@@ -250,20 +250,13 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.25.0",
@@ -1732,15 +1725,16 @@
       }
     },
     "node_modules/complex.js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
-      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/concat-map": {
@@ -2000,14 +1994,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
-      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
+      "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 12"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -2700,20 +2695,20 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "12.4.3",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.3.tgz",
-      "integrity": "sha512-oHdGPDbp7gO873xxG90RLq36IuicuKvbpr/bBG5g9c8Obm/VsKVrK9uoRZZHUodohzlnmCEqfDzbR3LH6m+aAQ==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.4.0.tgz",
+      "integrity": "sha512-CpoYDhNENefjIG9wU9epr+0pBHzlaySfpWcblZdAf5qXik/j/U8eSmx/oNbmXO0F5PyfwPGVD/wK4VWsTho1SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime": "^7.24.4",
-        "complex.js": "^2.1.1",
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
-        "fraction.js": "4.3.4",
+        "fraction.js": "^5.2.1",
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.1.1"
+        "typed-function": "^4.2.1"
       },
       "bin": {
         "mathjs": "bin/cli.js"
@@ -3581,11 +3576,12 @@
       }
     },
     "node_modules/typed-function": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
-      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/ufo": {
@@ -4312,19 +4308,9 @@
       "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA=="
     },
     "@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
-      "requires": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        }
-      }
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog=="
     },
     "@babel/template": {
       "version": "7.25.0",
@@ -5214,9 +5200,9 @@
       }
     },
     "complex.js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
-      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5412,9 +5398,9 @@
       }
     },
     "fraction.js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
-      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
+      "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ=="
     },
     "fs-extra": {
       "version": "11.2.0",
@@ -5867,19 +5853,19 @@
       }
     },
     "mathjs": {
-      "version": "12.4.3",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.3.tgz",
-      "integrity": "sha512-oHdGPDbp7gO873xxG90RLq36IuicuKvbpr/bBG5g9c8Obm/VsKVrK9uoRZZHUodohzlnmCEqfDzbR3LH6m+aAQ==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.4.0.tgz",
+      "integrity": "sha512-CpoYDhNENefjIG9wU9epr+0pBHzlaySfpWcblZdAf5qXik/j/U8eSmx/oNbmXO0F5PyfwPGVD/wK4VWsTho1SA==",
       "requires": {
-        "@babel/runtime": "^7.24.4",
-        "complex.js": "^2.1.1",
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
-        "fraction.js": "4.3.4",
+        "fraction.js": "^5.2.1",
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.1.1"
+        "typed-function": "^4.2.1"
       }
     },
     "merge-stream": {
@@ -6516,9 +6502,9 @@
       "dev": true
     },
     "typed-function": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
-      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA=="
     },
     "ufo": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "braces": "3.0.3",
     "country-to-currency": "^1.1.5",
     "lodash": "^4.17.21",
-    "mathjs": "^12.4.3",
+    "mathjs": "^14.4.0",
     "show-toast": "^1.1.4",
     "web-browser-storage": "^0.1.14"
   },


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Upgrade mathjs from ^12.4.3 to ^14.4.0 and refresh package-lock.json