### PR TITLE
fix: mobile device font sizes

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -152,24 +152,21 @@ body {
   line-height: 42px;
 }
 
-/* Mobile device Styles */
-@media (max-width: 600px) {
 
-  .editor,
-  .output,
-  .result-btn {
-    font-size: 90px;
-    line-height: 100px;
-  }
+.mobile-device .editor,
+.mobile-device .output,
+.mobile-device .result-btn {
+  font-size: 90px !important;
+  line-height: 100px !important;
+}
 
-  .history-editor,
-  .history-output,
-  .history-result-btn,
-  .history-editor-item,
-  .history-label {
-    font-size: 64px;
-    line-height: 72px;
-  }
+.mobile-device .history-editor,
+.mobile-device .history-output,
+.mobile-device .history-result-btn,
+.mobile-device .history-editor-item,
+.mobile-device .history-label {
+  font-size: 64px !important;
+  line-height: 72px !important;
 }
 
 .result {

--- a/css/editor.css
+++ b/css/editor.css
@@ -156,8 +156,8 @@ body {
 .mobile-device .editor,
 .mobile-device .output,
 .mobile-device .result-btn {
-  font-size: 90px !important;
-  line-height: 100px !important;
+  font-size: 84px !important;
+  line-height: 96px !important;
 }
 
 .mobile-device .history-editor,

--- a/css/editor.css
+++ b/css/editor.css
@@ -153,8 +153,7 @@ body {
 }
 
 /* Mobile device Styles */
-@media (max-width: 600px),
-(pointer: coarse) and (hover: none) {
+@media (max-width: 600px) {
 
   .editor,
   .output,
@@ -172,6 +171,7 @@ body {
     line-height: 72px;
   }
 }
+
 .result {
   color: var(--accent-result);
 }
@@ -236,23 +236,23 @@ body {
 
 .help-overlay {
   position: fixed;
-    /* Sit on top of the page content */
-    display: none;
-    /* Hidden by default */
-    width: 100%;
-    /* Full width (cover the whole page) */
-    height: 100%;
-    /* Full height (cover the whole page) */
+  /* Sit on top of the page content */
+  display: none;
+  /* Hidden by default */
+  width: 100%;
+  /* Full width (cover the whole page) */
+  height: 100%;
+  /* Full height (cover the whole page) */
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
   background-color: var(--input-background);
-    /* background with opacity */
-    z-index: 2;
-    /* Specify a stack order in case you're using a different order for other elements */
-    cursor: pointer;
-    /* Add a pointer on hover */
+  /* background with opacity */
+  z-index: 2;
+  /* Specify a stack order in case you're using a different order for other elements */
+  cursor: pointer;
+  /* Add a pointer on hover */
   overflow-y: auto;
 }
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -7,6 +7,8 @@ import showToast from "show-toast";
 import { LocalStorage } from "web-browser-storage";
 import { createUnit, unit, evaluate as mathjs_evaluate } from "mathjs";
 import { callAI } from "./AI.js";
+import { isMobile } from 'mobile-device-detect';
+
 const storage = new LocalStorage();
 var _ = require("lodash");
 
@@ -30,7 +32,16 @@ let editorWidthBefore;
 let outputWidthBefore;
 let historyToggleButton;
 
-document.addEventListener("DOMContentLoaded", init);
+function setMobileDeviceClass() {
+  if (isMobile) {
+    document.body.classList.add('mobile-device');
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  setMobileDeviceClass();
+  init();
+});
 
 export async function setupHomeCurrency() {
   const fallbackHomeCurrency = "USD";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "country-to-currency": "^1.1.5",
         "lodash": "^4.17.21",
         "mathjs": "^14.4.0",
+        "mobile-device-detect": "^0.4.3",
         "show-toast": "^1.1.4",
         "web-browser-storage": "^0.1.14"
       },
@@ -3175,6 +3176,12 @@
         "pkg-types": "^1.1.0",
         "ufo": "^1.5.3"
       }
+    },
+    "node_modules/mobile-device-detect": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/mobile-device-detect/-/mobile-device-detect-0.4.3.tgz",
+      "integrity": "sha512-SN9EBE9SoJgkb83kuUVoIp3R9OGYE5dYEnLEz2oLooh0DzgtQ72BJmpNGqrgFvmfE4iLR2CaVJ3RjUcStheVZg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6728,6 +6735,11 @@
         "pkg-types": "^1.1.0",
         "ufo": "^1.5.3"
       }
+    },
+    "mobile-device-detect": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/mobile-device-detect/-/mobile-device-detect-0.4.3.tgz",
+      "integrity": "sha512-SN9EBE9SoJgkb83kuUVoIp3R9OGYE5dYEnLEz2oLooh0DzgtQ72BJmpNGqrgFvmfE4iLR2CaVJ3RjUcStheVZg=="
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "lodash": "^4.17.21",
     "mathjs": "^14.4.0",
     "show-toast": "^1.1.4",
-    "web-browser-storage": "^0.1.14"
+    "web-browser-storage": "^0.1.14",
+    "mobile-device-detect": "^0.4.3"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^1.6.0",


### PR DESCRIPTION
## Summary by Sourcery

Apply mobile CSS strictly based on screen width and tidy up help-overlay CSS formatting.

Bug Fixes:
- Remove pointer/hover media query clause so mobile font sizes and styles correctly apply on narrow screens.

Enhancements:
- Standardize comment indentation in the .help-overlay CSS block.